### PR TITLE
Add library.properties metadata file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=pca9633
+version=0.0.0
+author=Gordon McLellan
+maintainer=Gordon McLellan
+sentence=Control NXP PCA9633 (and 9632) four channel PWM led driver chips.
+paragraph=
+category=Device Control
+url=https://github.com/gordonthree/pca9633
+architectures=*
+includes=pca9633.h


### PR DESCRIPTION
Libraries in the Arduino Library 1.5 format (source files under the src subfolder) are required to have a library.properties file in the root folder. If this file is not present the library is not recognized by the Arduino IDE.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata